### PR TITLE
dockerhub tagging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
   - echo "ENV GIT_COMMIT ${TRAVIS_COMMIT}" >> Dockerfile
 
 script:
+  - sh ./.travis/check_semver
   - docker build --tag "${DOCKER_LOCAL}" .
 
 # develop-branch pushes the image with "latest"-tag. Tagged commit will push the image with fully versioned tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
   - echo "ENV GIT_COMMIT ${TRAVIS_COMMIT}" >> Dockerfile
 
 script:
+  - set -e
   - ./.travis/check_semver
   - docker build --tag "${DOCKER_LOCAL}" .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,14 @@ before_install:
 script:
   - docker build --tag "${DOCKER_LOCAL}" .
 
+# develop-branch pushes the image with "latest"-tag, tagged commit on master-branch will push the image with the versioned tags
 deploy:
   - provider: script
     script: sh ./.travis/docker_login_tag_push "${DOCKER_LOCAL}" "${DOCKER_MASTER}"
     on:
-      branch: master
+      branch: develop
   - provider: script
-    script: sh ./.travis/docker_login_tag_semver_push "${DOCKER_LOCAL}" "${LOWERCASE_REPO_SLUG}" "${TRAVIS_TAG}"
+    script: sh ./.travis/docker_login_tag_semver_push "${DOCKER_LOCAL}" "${LOWERCASE_REPO_SLUG}" "${TRAVIS_TAG}" "${TRAVIS_COMMIT}"
     on:
       tags: true
-      all_branches: true
+      branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - LOWERCASE_REPO_SLUG="${TRAVIS_REPO_SLUG,,}"
     - DOCKER_LOCAL="${LOWERCASE_REPO_SLUG}:${TRAVIS_COMMIT}"
     - DOCKER_MASTER="${LOWERCASE_REPO_SLUG}:latest"
-    - BUILD_HASH=echo "${TRAVIS_COMMIT}" | cut -c1-7
+    - BUILD_HASH=$(echo "${TRAVIS_COMMIT}" | cut -c1-7)
 
 before_install:
   - docker --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ jdk:
 services:
   - docker
 
+addons:
+  apt:
+    packages:
+      # Needed for `xmllint`.
+      - libxml2-utils
+
 env:
   global:
     # Docker Hub cannot handle uppercase characters in repository names. Fix it

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
     - LOWERCASE_REPO_SLUG="${TRAVIS_REPO_SLUG,,}"
     - DOCKER_LOCAL="${LOWERCASE_REPO_SLUG}:${TRAVIS_COMMIT}"
     - DOCKER_MASTER="${LOWERCASE_REPO_SLUG}:latest"
+    - BUILD_HASH=echo "${TRAVIS_COMMIT}" | cut -c1-7
 
 before_install:
   - docker --version
@@ -23,14 +24,14 @@ before_install:
 script:
   - docker build --tag "${DOCKER_LOCAL}" .
 
-# develop-branch pushes the image with "latest"-tag, tagged commit on master-branch will push the image with the versioned tags
+# develop-branch pushes the image with "latest"-tag. Tagged commit will push the image with fully versioned tags
 deploy:
   - provider: script
     script: sh ./.travis/docker_login_tag_push "${DOCKER_LOCAL}" "${DOCKER_MASTER}"
     on:
       branch: develop
   - provider: script
-    script: sh ./.travis/docker_login_tag_semver_push "${DOCKER_LOCAL}" "${LOWERCASE_REPO_SLUG}" "${TRAVIS_TAG}" "${TRAVIS_COMMIT}"
+    script: sh ./.travis/docker_login_tag_semver_push "${DOCKER_LOCAL}" "${LOWERCASE_REPO_SLUG}" "${TRAVIS_TAG}" "${BUILD_HASH}"
     on:
       tags: true
-      branch: master
+      all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   - echo "ENV GIT_COMMIT ${TRAVIS_COMMIT}" >> Dockerfile
 
 script:
-  - sh ./.travis/check_semver
+  - ./.travis/check_semver
   - docker build --tag "${DOCKER_LOCAL}" .
 
 # develop-branch pushes the image with "latest"-tag. Tagged commit will push the image with fully versioned tags

--- a/.travis/check_semver
+++ b/.travis/check_semver
@@ -1,8 +1,8 @@
-#!/bin/sh
+#!/bin/bash
 
 matches_semver() {
   # Simple regex-check, allows optionally three levels separated with .
-  if [ "$1" =~ [0-9]+(\.[0-9]+(\.[0-9]+)?)?$ ]; then
+  if [[ "$1" =~ [0-9]+(\.[0-9]+(\.[0-9]+)?)?$ ]]; then
     # 0 = true
     return 0
   else

--- a/.travis/check_semver
+++ b/.travis/check_semver
@@ -2,7 +2,7 @@
 
 matches_semver() {
   # Simple regex-check, allows optionally three levels separated with .
-  if [[ "$1" =~ [0-9]+(\.[0-9]+(\.[0-9]+)?)?$ ]]; then
+  if [ "$1" =~ [0-9]+(\.[0-9]+(\.[0-9]+)?)?$ ]; then
     # 0 = true
     return 0
   else

--- a/.travis/check_semver
+++ b/.travis/check_semver
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -u
+
+if [ -n "${TRAVIS_TAG}" ]; then
+  TRAVIS_SEMVER="$(semver "${TRAVIS_TAG}")"
+  if [ "$?" -ne 0 ]; then
+    echo "TRAVIS_TAG ${TRAVIS_TAG} does not follow semver" 1>&2
+    exit 1
+  fi
+  PACKAGE_VERSION="$(xmllint --nsclean --xpath '/project/version/text()' pom.xml)"
+  PACKAGE_SEMVER="$(semver "${PACKAGE_VERSION}")"
+  if [ "$?" -ne 0 ]; then
+    echo "version ${PACKAGE_VERSION} in pom.xml does not follow semver" 1>&2
+    exit 1
+  fi
+  if [ "${TRAVIS_SEMVER}" != "${PACKAGE_VERSION}" ]; then
+    echo "According to semver, TRAVIS_TAG ${TRAVIS_TAG} differs from version ${PACKAGE_VERSION} in pom.xml" 1>&2
+    exit 1
+  fi
+fi

--- a/.travis/check_semver
+++ b/.travis/check_semver
@@ -1,11 +1,8 @@
 #!/bin/sh
 
 matches_semver() {
-  #REGEX="\d+\.\d+\.\d+(\-[0-9a-f]{0,40})?"
-  echo "test $1"
-  #if [[ "$1" =~ $REGEX ]]; then
-  #if [[ "$1" =~ '\d+\.\d+\.\d+\(\-[0-9a-f]{0,40}\)?' ]]; then
-  if [[ "$1" =~ [0-9]+\.[0-9]+\.[0-9]+(-[0-9a-f]{0,40})? ]]; then
+  # Simple regex-check, allows optionally three levels separated with .
+  if [[ "$1" =~ [0-9]+(\.[0-9]+(\.[0-9]+)?)?$ ]]; then
     # 0 = true
     return 0
   else
@@ -13,9 +10,9 @@ matches_semver() {
     return 1
   fi
 }
-matches_semver "11.13.2"
+
 set -u
-matches_semver "1.1.1-abc"
+
 if [ -n "${TRAVIS_TAG}" ]; then
   TRAVIS_SEMVER="$(matches_semver "${TRAVIS_TAG}")"
   if [ "$?" -ne 0 ]; then

--- a/.travis/check_semver
+++ b/.travis/check_semver
@@ -1,21 +1,37 @@
 #!/bin/sh
 
+matches_semver() {
+  #REGEX="\d+\.\d+\.\d+(\-[0-9a-f]{0,40})?"
+  echo "test $1"
+  #if [[ "$1" =~ $REGEX ]]; then
+  #if [[ "$1" =~ '\d+\.\d+\.\d+\(\-[0-9a-f]{0,40}\)?' ]]; then
+  if [[ "$1" =~ [0-9]+\.[0-9]+\.[0-9]+(-[0-9a-f]{0,40})? ]]; then
+    # 0 = true
+    return 0
+  else
+    # 1 = false
+    return 1
+  fi
+}
+matches_semver "11.13.2"
 set -u
-
+matches_semver "1.1.1-abc"
 if [ -n "${TRAVIS_TAG}" ]; then
-  TRAVIS_SEMVER="$(semver "${TRAVIS_TAG}")"
+  TRAVIS_SEMVER="$(matches_semver "${TRAVIS_TAG}")"
   if [ "$?" -ne 0 ]; then
     echo "TRAVIS_TAG ${TRAVIS_TAG} does not follow semver" 1>&2
     exit 1
   fi
   PACKAGE_VERSION="$(xmllint --nsclean --xpath '/project/version/text()' pom.xml)"
-  PACKAGE_SEMVER="$(semver "${PACKAGE_VERSION}")"
+  PACKAGE_SEMVER="$(matches_semver "${PACKAGE_VERSION}")"
   if [ "$?" -ne 0 ]; then
     echo "version ${PACKAGE_VERSION} in pom.xml does not follow semver" 1>&2
     exit 1
   fi
-  if [ "${TRAVIS_SEMVER}" != "${PACKAGE_VERSION}" ]; then
+  if [ "${TRAVIS_TAG}" != "${PACKAGE_VERSION}" ]; then
     echo "According to semver, TRAVIS_TAG ${TRAVIS_TAG} differs from version ${PACKAGE_VERSION} in pom.xml" 1>&2
     exit 1
+  else
+    echo "Travis tag and pom.xml versions match"
   fi
 fi

--- a/.travis/docker_login_tag_semver_push
+++ b/.travis/docker_login_tag_semver_push
@@ -2,14 +2,17 @@
 
 set -u
 
-[ "$#" -ne 3 ] && {
-  echo "Usage: $(basename "$0") SOURCE_IMAGE[:TAG] TARGET_IMAGE_WITHOUT_TAG TRAVIS_TAG" 1>&2
+[ "$#" -lt 3 ] && {
+  echo "Usage: $(basename "$0") SOURCE_IMAGE[:TAG] TARGET_IMAGE_WITHOUT_TAG TRAVIS_TAG [BUILD_HASH]" 1>&2
   exit 1
 }
 
 SOURCE_IMAGE_TAG="$1"
 TARGET_IMAGE_WITHOUT_TAG="$2"
 TAG_FROM_TRAVIS="$3"
+if [ "$#" -ge 4 ]; then
+  BUILD_HASH="$4"
+fi
 
 PUSH='./.travis/docker_login_tag_push'
 
@@ -27,6 +30,9 @@ if [ "${IS_PRE_RELEASE}" != true ]; then
   SEMVER_MAJOR="$(echo "${SEMVER_MINOR}" | cut -d . -f 1)"
   TARGET_IMAGES="${TARGET_IMAGES} ${TARGET_IMAGE_WITHOUT_TAG}:${SEMVER_MINOR}"
   TARGET_IMAGES="${TARGET_IMAGES} ${TARGET_IMAGE_WITHOUT_TAG}:${SEMVER_MAJOR}"
+  if [ -n "${BUILD_HASH-}" ]; then
+    TARGET_IMAGES="${TARGET_IMAGES} ${TARGET_IMAGE_WITHOUT_TAG}:${SEMVER_FULL}-${BUILD_HASH}"
+  fi
 fi
-
+echo "Pushing source image with tags $TARGET_IMAGES"
 "${PUSH}" "${SOURCE_IMAGE_TAG}" ${TARGET_IMAGES}


### PR DESCRIPTION
- When pushing to develop we push image to dockerhub with tag *latest*. 
- When pushing a tag (from any commit / branch) we push image to dockerhub with semver tags, fex: version 1.2.3 will push following tags to that image: 
  - 1
  - 1.2
  - 1.2.3
  - 1.2.3-abcdefg (git short hash)

before pushing the tagged versions we validate that 
- tag is according to semver format: x.y.z
- pom.xml has the same version string as is the tag, f.ex 0.1.0